### PR TITLE
Fix the build error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,10 @@ permalink: pretty
 search_enabled: true
 color_scheme: dark
 
+# Remote Setting
+baseurl: "/guidelines"
+# url: ""
+
+# Theme
+# theme: "just-the-docs"
 remote_theme: pmarsceill/just-the-docs
-plugins:
-  - jekyll-remote-theme


### PR DESCRIPTION
Current error: Using theme pmarsceill/just-the-docs
jekyll 3.9.0 | Error:  404 - Not Found

Solution found here: https://stackoverflow.com/questions/56464757/trouble-implementing-specifically-just-the-docs-theme-using-jekyll

<!--This is a pull request template, and everything in these brackets won't appear when you open the pull request. They're comments.-->
### Change added

- <!--Here, describe the changes you're introducing. In this pull request, you're introducing a configuration file for CircleCI.-->
